### PR TITLE
use torch.no_grad scope when inferencing

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -11,37 +11,38 @@ from model.embedder import SpeechEmbedder
 
 
 def main(args, hp):
-    model = VoiceFilter(hp).cuda()
-    chkpt_model = torch.load(args.checkpoint_path)['model']
-    model.load_state_dict(chkpt_model)
-    model.eval()
+    with torch.no_grad():
+        model = VoiceFilter(hp).cuda()
+        chkpt_model = torch.load(args.checkpoint_path)['model']
+        model.load_state_dict(chkpt_model)
+        model.eval()
 
-    embedder = SpeechEmbedder(hp).cuda()
-    chkpt_embed = torch.load(args.embedder_path)
-    embedder.load_state_dict(chkpt_embed)
-    embedder.eval()
+        embedder = SpeechEmbedder(hp).cuda()
+        chkpt_embed = torch.load(args.embedder_path)
+        embedder.load_state_dict(chkpt_embed)
+        embedder.eval()
 
-    audio = Audio(hp)
-    dvec_wav, _ = librosa.load(args.reference_file, sr=16000)
-    dvec_mel = audio.get_mel(dvec_wav)
-    dvec_mel = torch.from_numpy(dvec_mel).float().cuda()
-    dvec = embedder(dvec_mel)
-    dvec = dvec.unsqueeze(0)
+        audio = Audio(hp)
+        dvec_wav, _ = librosa.load(args.reference_file, sr=16000)
+        dvec_mel = audio.get_mel(dvec_wav)
+        dvec_mel = torch.from_numpy(dvec_mel).float().cuda()
+        dvec = embedder(dvec_mel)
+        dvec = dvec.unsqueeze(0)
 
-    mixed_wav, _ = librosa.load(args.mixed_file, sr=16000)
-    mag, phase = audio.wav2spec(mixed_wav)
-    mag = torch.from_numpy(mag).float().cuda()
+        mixed_wav, _ = librosa.load(args.mixed_file, sr=16000)
+        mag, phase = audio.wav2spec(mixed_wav)
+        mag = torch.from_numpy(mag).float().cuda()
 
-    mag = mag.unsqueeze(0)
-    mask = model(mag, dvec)
-    est_mag = mag * mask
+        mag = mag.unsqueeze(0)
+        mask = model(mag, dvec)
+        est_mag = mag * mask
 
-    est_mag = est_mag[0].cpu().detach().numpy()
-    est_wav = audio.spec2wav(est_mag, phase)
+        est_mag = est_mag[0].cpu().detach().numpy()
+        est_wav = audio.spec2wav(est_mag, phase)
 
-    os.makedirs(args.out_dir, exist_ok=True)
-    out_path = os.path.join(args.out_dir, 'result.wav')
-    librosa.output.write_wav(out_path, est_wav, sr=16000)
+        os.makedirs(args.out_dir, exist_ok=True)
+        out_path = os.path.join(args.out_dir, 'result.wav')
+        librosa.output.write_wav(out_path, est_wav, sr=16000)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This reduces the usage of GPU memory when inferencing about half.

Missing `torch.no_grad()` scope in `inference.py` was my mistake.