### PR TITLE
fix pytorch version to 1.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 tqdm
 numpy
-torch
+torch==1.0.1
 pyyaml
 librosa
 mir_eval


### PR DESCRIPTION
It's 1.0.2 on pypi and 1.1.0 on the way.

p.s. It would be great if you plan to migrate from `requirements.txt` to `pipenv` for versioning. It would help you resolve version and lock them for you automatically.