### PR TITLE
search for flac instead of wav when normalize

### DIFF
--- a/utils/normalize-resample.sh
+++ b/utils/normalize-resample.sh
@@ -21,6 +21,6 @@ run_with_lock(){
 
 N=32 # set "N" as your CPU core number.
 open_sem $N
-for f in $(find . -name "*.wav"); do
+for f in $(find . -name "*.flac"); do
     run_with_lock ffmpeg-normalize "$f" -ar 16000 -o "${f%.*}-norm.wav"
 done


### PR DESCRIPTION
The format I download from slr seems to be `flac` instead of `wav`. Also it's mentioned in https://github.com/mindslab-ai/voicefilter/issues/9#issuecomment-523010523