### PR TITLE
Adding specific versions to librosa and numba

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,9 @@ tqdm
 numpy
 torch==1.0.1
 pyyaml
-librosa
+librosa==0.6.3
 mir_eval
 matplotlib
 tensorboardX
 Pillow
+numba==0.48


### PR DESCRIPTION
Newer packages of those libraries have changed things and the methods used in the code are no longer available. Setting specific versions in the requirements file avoids installing those versions.